### PR TITLE
Add remote SSH test workflow

### DIFF
--- a/workflows/remote-ssh-test.yml
+++ b/workflows/remote-ssh-test.yml
@@ -1,0 +1,20 @@
+name: Remote SSH Test
+
+on:
+  workflow_dispatch:
+
+jobs:
+  ssh-test:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Execute remote SSH commands
+        uses: appleboy/ssh-action@v1
+        with:
+          host: ${{ secrets.SSH_HOST }}
+          username: ${{ secrets.SSH_USER }}
+          key: ${{ secrets.SSH_KEY }}
+          port: ${{ secrets.SSH_PORT }}
+          script: |
+            whoami
+            ls -la


### PR DESCRIPTION
This pull request introduces a new GitHub Actions workflow to facilitate remote SSH testing. The workflow allows executing commands on a remote server via SSH using the `appleboy/ssh-action` action.

### New Workflow Addition:

* [`workflows/remote-ssh-test.yml`](diffhunk://#diff-0ce7f0f00bf2f52a0248741780422de1678016dd68abdede23d85ecd083c35c1R1-R20): Added a new workflow named "Remote SSH Test" that can be triggered manually (`workflow_dispatch`). It includes a job (`ssh-test`) to execute remote SSH commands using secrets for host, user, key, and port configuration. The script runs basic commands like `whoami` and `ls -la`.