### PR TITLE
Add dependabot config

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,17 @@
+# To get started with Dependabot version updates, you'll need to specify which
+# package ecosystems to update and where the package manifests are located.
+# Please see the documentation for all configuration options:
+# https://docs.github.com/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file
+
+version: 2
+updates:
+# Fetch and update latest `github-actions` packages
+- package-ecosystem: "github-actions"
+  directory: "/"
+  schedule:
+    interval: "daily"
+  open-pull-requests-limit: 10
+  commit-message:
+    prefix: fix
+    prefix-development: routine
+    include: scope


### PR DESCRIPTION
This pull request introduces a new `.github/dependabot.yml` configuration file to automate dependency updates for `github-actions` packages. The configuration is set to fetch updates daily and includes options to limit open pull requests and customize commit message prefixes.

Key changes:

### Dependabot configuration:

* Added a `.github/dependabot.yml` file to enable automated updates for `github-actions` dependencies. The updates are scheduled daily, with a limit of 10 open pull requests, and include customized commit message prefixes.